### PR TITLE
Fix spelling mistake and remove debugging statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,14 +255,14 @@ Fetches the reviews a bot has recieved. Requires authorization.
 
 |Attribute|Type|Description|
 |---|---|---|
-|reviews|List[`blist.models.Review`]|List of reviews on the bot. Contains the feedback, whether it is recomended and the time|
+|reviews|List[`blist.models.Review`]|List of reviews on the bot. Contains the feedback, whether it is recommended and the time|
 
 **`blist.models.Review`**
 
 |Attribute|Type|Description|
 |---|---|---|
 |feedback|`str`|The way the reviewing user felt about the bot|
-|recomended|`bool`|Whether the reviewing user recomends the bot to other users|
+|recommended|`bool`|Whether the reviewing user recommends the bot to other users|
 |time|`datetime.datetime`|The timestamp of when the user left the review|
 
 **Return Type**
@@ -283,7 +283,7 @@ Disallows the `blist.Blist` instance from being used to make anymore requests to
 
 ### `blist.WebhookServer(blist, port=8000)`
 
-*This method has been disabled ufn*
+*This method has been disabled until further notice.*
 
 Server for receiving upvote events and dispatching them.
 
@@ -305,7 +305,7 @@ Server for receiving upvote events and dispatching them.
 
 ### `await blist.WebhookServer.run()`
 
-*This method has been disabled ufn*
+*This method has been disabled until further notice.*
 
 *This method is a coroutine.*
 
@@ -317,7 +317,7 @@ Starts the webhook server and allows it to serve requests.
 
 ### `await blist.WebhookServer.close()`
 
-*This method has been disabled ufn*
+*This method has been disabled until further notice.*
 
 *This method is a coroutine.*
 

--- a/blist/api.py
+++ b/blist/api.py
@@ -101,9 +101,8 @@ class Blist:
 
         response = await self._session.get(f"{self.BASE_URL}/bot/{self.bot.user.id}/reviews/", headers=headers)
         json = await response.json()
-        
+
         if response.status == 200:
-            print(json)
             return models.Reviews(**json)
 
         if response.status == 403:

--- a/blist/models.py
+++ b/blist/models.py
@@ -79,11 +79,14 @@ class Votes:
 class Review:
     def __init__(self, **kwargs):
         self.feedback: str = kwargs.get("feedback")
-        self.recomended: bool = kwargs.get("recomended")
+        self.recommended: bool = kwargs.get("recommended")
+        # legacy support for applications currently using the misspelled word
+        # present in one version
+        self.recomended: bool = self.recommended
         self.time: datetime.datetime = parser.parse(kwargs.get("time"))
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} feedback={self.feedback} recomended={self.recomended}>"
+        return f"<{self.__class__.__name__} feedback={self.feedback} recommended={self.recommended}>"
 
 class Reviews:
     def __init__(self, **kwargs):

--- a/blist/models.py
+++ b/blist/models.py
@@ -79,7 +79,7 @@ class Votes:
 class Review:
     def __init__(self, **kwargs):
         self.feedback: str = kwargs.get("feedback")
-        self.recommended: bool = kwargs.get("recommended")
+        self.recommended: bool = kwargs.get("recomended")
         # legacy support for applications currently using the misspelled word
         # present in one version
         self.recomended: bool = self.recommended

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("PIP_README.md", encoding="utf-8") as pip_readme:
 
 setuptools.setup(
     name="blistpy",
-    version="0.1.0",
+    version="0.1.1",
     author="Joshua Patel & Gavyn Stanley",
     description="Python API wrapper for the Blist Discord bot list",
     long_description=description,


### PR DESCRIPTION
This PR fixes a spelling issue and removes a call to the `print` method used for debugging.

I highly recommend looking over your code before you push directly to `master`. Submitting a pull request would be preferable so that the community can notice these issues before it's too late.

Cheers!